### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 [![smithery badge](https://smithery.ai/badge/@kjozsa/jenkins-mcp)](https://smithery.ai/server/@kjozsa/jenkins-mcp)
 MCP server for managing Jenkins operations.
 
+<a href="https://glama.ai/mcp/servers/7j3zk84u5p">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/7j3zk84u5p/badge" alt="Jenkins MCP server" />
+</a>
+
 ## Installation
 ### Installing via Smithery
 


### PR DESCRIPTION
This PR adds a badge for the [Jenkins MCP](https://glama.ai/mcp/servers/7j3zk84u5p) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/7j3zk84u5p">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/7j3zk84u5p/badge" alt="Jenkins MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.